### PR TITLE
fix: correct spelling of location in event details

### DIFF
--- a/src/components/EventCarousel.astro
+++ b/src/components/EventCarousel.astro
@@ -20,7 +20,7 @@ const EVENTS: EventArray[] = [
         date: "Feb 8",
         description: "Annual summer sports competition",
         sport: "Swimming",
-        location: "Thustan Swimming Pool",
+        location: "Thurstan Swimming Pool",
     },
 ];
 


### PR DESCRIPTION
Update the location of the swimming event from "Thustan" to 
"Thurstan"