### PR TITLE
fix: correct spelling of 'Championship' in event title

### DIFF
--- a/src/components/EventCarousel.astro
+++ b/src/components/EventCarousel.astro
@@ -16,7 +16,7 @@ interface EventArray {
 const EVENTS: EventArray[] = [
     {
         id: 1,
-        title: "Freshers Swimming Champoinship",
+        title: "Freshers Swimming Championship",
         date: "Feb 8",
         description: "Annual summer sports competition",
         sport: "Swimming",


### PR DESCRIPTION
Update the title of the Freshers Swimming Championship event to 
correct the spelling from 'Champoinship' to 'Championship'. This 
ensures accuracy and professionalism in the event listing.