### PR TITLE
fix(HeatTable): correctly display swimmer's last name

### DIFF
--- a/src/components/HeatTable.jsx
+++ b/src/components/HeatTable.jsx
@@ -85,7 +85,7 @@ const HeatTable = ({ results }) => {
                     {swimmer.name}
                   </td>
                   <td className="md:hidden px-2 text-sm py-4 align-middle">
-                    {swimmer.name.split(" ")[-1]}
+                    {swimmer.name.split(" ")[1]}
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
Change the index used to extract the last name from the swimmer's
full name from -1 to 1. This fixes an issue where last name wasnot displayed correctly on smaller screens, improving the UI's
accuracy and readability.