### PR TITLE
fix(event-carousel): update event date and disable promo section

### DIFF
--- a/src/components/EventCarousel.astro
+++ b/src/components/EventCarousel.astro
@@ -29,7 +29,7 @@ const EVENTS: EventArray[] = [
     {
         id: 1,
         title: "Inter Faculty Swimming Championship",
-        date: "Feb 8",
+        date: "June 28",
         description: "Annual summer sports competition",
         sport: "Swimming",
         location: "Thurstan Swimming Pool",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,7 +5,7 @@ import Image from "astro/components/Image.astro";
 import "../styles/global.css";
 import EventCarousel from "../components/EventCarousel.astro";
 
-import PromoCompact from "../components/PromoCompact.astro";
+// import PromoCompact from "../components/PromoCompact.astro";
 ---
 
 <!doctype html>
@@ -37,9 +37,9 @@ import PromoCompact from "../components/PromoCompact.astro";
             <!-- <Navigation /> -->
             <main class="min-h-dvh p-6 max-w-[1440px]">
                 <EventCarousel />
-                <div id="promoContainer" class="mt-2 w-full justify-center">
+                <!-- <div id="promoContainer" class="mt-2 w-full justify-center">
                     <PromoCompact />
-                </div>
+                </div> -->
                 <slot />
             </main>
             <footer
@@ -71,7 +71,7 @@ import PromoCompact from "../components/PromoCompact.astro";
                 </div>
             </footer>
         </div>
-        <script>
+        <!-- <script>
             const showPromo = () => {
                 const promoContainer =
                     document.getElementById("promoContainer");
@@ -112,6 +112,6 @@ import PromoCompact from "../components/PromoCompact.astro";
                     setTimeout(showPromo, intervalDelay);
                 }, 60000);
             }, initialDelay);
-        </script>
+        </script> -->
     </body>
 </html>


### PR DESCRIPTION
Change the date of the "Inter Faculty Swimming Championship" event
from "Feb 8" to "June 28" to reflect the correct schedule.

Comment out the PromoCompact component and related promo container
markup and script in the layout to temporarily disable promotional
content, likely for maintenance or to prevent display issues.