### PR TITLE
fix(constants): update relay distances from 25m to 50m

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -39,8 +39,8 @@ export const EVENT_OPTIONS = [
   {
     label: "Relay",
     items: [
-      { label: "4x25m Freestyle Relay", value: 16 },
-      { label: "4x25m Medley Relay", value: 17 },
+      { label: "4x50m Freestyle Relay", value: 16 },
+      { label: "4x50m Medley Relay", value: 17 },
     ],
   },
 ];


### PR DESCRIPTION
Change relay event distances from 4x25m to 4x50m in the constants
to reflect the correct race lengths. This ensures accurate event
labeling and consistency with official competition standards.