### PR TITLE
feat: conditionally hide Name column for relay events

### DIFF
--- a/src/components/EventLeaderboard.jsx
+++ b/src/components/EventLeaderboard.jsx
@@ -32,6 +32,7 @@ export default function EventLeaderboard() {
         `https://opensheet.elk.sh/1Hww9j0A8B4cc24gzqDgK5alCsr5kG3nE1uYjSc9HiN0/${event}`,
       );
       const data = await response.json();
+      // console.log(data);
       setData(data);
     };
     fetchData();
@@ -39,7 +40,7 @@ export default function EventLeaderboard() {
 
   const selectedEventObject = EVENT_OPTIONS.flatMap(
     (group) => group.items,
-  ).find((item) => item.value === event % 16);
+  ).find((item) => item.value === event % 19);
 
   return (
     <div className="flex h-full flex-col rounded-xl bg-[var(--color-muted)]/60 p-4 md:col-span-2">
@@ -186,9 +187,12 @@ export default function EventLeaderboard() {
         </div>
 
         <div className="mt-4">
-          {}
-          {data && view === "table" && <EventTable data={data} />}
-          {data && view === "heats" && <HeatTable results={data} />}
+          {data && view === "table" && (
+            <EventTable data={data} eventNum={event} />
+          )}
+          {data && view === "heats" && (
+            <HeatTable results={data} eventNum={event} />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/EventTable.jsx
+++ b/src/components/EventTable.jsx
@@ -1,6 +1,7 @@
 // import { FACULTY_OPTIONS } from "../lib/constants";
+const relay = [16, 17, 32, 33];
 
-export default function EventTable({ data }) {
+export default function EventTable({ data, eventNum }) {
   return (
     <div className="relative w-full overflow-auto">
       <table className="w-full caption-bottom text-xs">
@@ -18,12 +19,14 @@ export default function EventTable({ data }) {
             >
               Faculty
             </th>
-            <th
-              scope="col"
-              className="px-2 text-xs md:text-sm md:px-3 h-12 text-left align-middle font-medium text-[var(--color-muted-foreground)]"
-            >
-              Name
-            </th>
+            {!relay.includes(eventNum) && (
+              <th
+                scope="col"
+                className="px-2 text-xs md:text-sm md:px-3 h-12 text-left align-middle font-medium text-[var(--color-muted-foreground)]"
+              >
+                Name
+              </th>
+            )}
             <th
               scope="col"
               className="px-2 text-xs md:text-sm md:px-3 h-12 text-left align-middle font-medium text-[var(--color-muted-foreground)]"
@@ -35,7 +38,7 @@ export default function EventTable({ data }) {
         <tbody className="[&_tr:last-child]:border-0">
           {data.map(
             (event, index) =>
-              event.Name && (
+              event.Faculty && (
                 <tr
                   key={index}
                   className="border-[var(--color-border)] transition-colors hover:bg-[var(--color-background)]/50"
@@ -48,12 +51,16 @@ export default function EventTable({ data }) {
                       {event.Faculty}
                     </span>
                   </td>
-                  <td className="hidden md:table-cell px-2 text-xs justify-center md:text-sm py-4 align-middle">
-                    {event.Name}
-                  </td>
-                  <td className="md:hidden px-2 text-xs justify-center md:text-sm py-4 align-middle">
-                    {event.Name.split(" ")[0]}
-                  </td>
+                  {!relay.includes(eventNum) && (
+                    <td className="hidden md:table-cell px-2 text-xs justify-center md:text-sm py-4 align-middle">
+                      {event.Name}
+                    </td>
+                  )}
+                  {!relay.includes(eventNum) && (
+                    <td className="md:hidden px-2 text-xs justify-center md:text-sm py-4 align-middle">
+                      {event.Name.split(" ")[0]}
+                    </td>
+                  )}
                   <td className="px-2 text-xs justify-center md:text-sm py-4 align-middle">
                     {event.Timing}
                   </td>

--- a/src/components/HeatTable.jsx
+++ b/src/components/HeatTable.jsx
@@ -1,6 +1,7 @@
 // import { FACULTY_OPTIONS } from "../lib/constants";
+const relay = [16, 17, 32, 33];
 
-const HeatTable = ({ results }) => {
+const HeatTable = ({ results, eventNum = 1 }) => {
   const validSwimmers = results.filter((s) => s.Heat !== "" && s.Lane !== "");
 
   const sortedSwimmers = [...validSwimmers].sort((a, b) => {
@@ -33,6 +34,8 @@ const HeatTable = ({ results }) => {
     });
   });
 
+  // console.log(eventNum, relay, relay.includes(eventNum));
+
   const heats = Array.from(heatsMap.values()).sort(
     (a, b) => parseInt(a.heatNumber, 10) - parseInt(b.heatNumber, 10),
   );
@@ -59,12 +62,14 @@ const HeatTable = ({ results }) => {
                 >
                   Faculty
                 </th>
-                <th
-                  scope="col"
-                  className="px-2 text-xs md:text-sm md:px-3 h-12 text-left align-middle font-medium text-[var(--color-muted-foreground)]"
-                >
-                  Name
-                </th>
+                {!relay.includes(eventNum) && (
+                  <th
+                    scope="col"
+                    className="px-2 text-xs md:text-sm md:px-3 h-12 text-left align-middle font-medium text-[var(--color-muted-foreground)]"
+                  >
+                    Name
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody className="[&_tr:last-child]:border-0">
@@ -81,12 +86,16 @@ const HeatTable = ({ results }) => {
                       {swimmer.faculty}
                     </span>
                   </td>
-                  <td className="hidden md:table-cell px-2 text-sm py-4 align-middle">
-                    {swimmer.name}
-                  </td>
-                  <td className="md:hidden px-2 text-sm py-4 align-middle">
-                    {swimmer.name.split(" ")[1]}
-                  </td>
+                  {!relay.includes(eventNum) && (
+                    <td className="hidden md:table-cell px-2 text-xs justify-center md:text-sm py-4 align-middle">
+                      {swimmer.name}
+                    </td>
+                  )}
+                  {!relay.includes(eventNum) && (
+                    <td className="md:hidden px-2 text-xs justify-center md:text-sm py-4 align-middle">
+                      {swimmer.name.split(" ")[0]}
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
Add logic to EventTable and HeatTable to omit the Name column for relay
events (event numbers 16, 17, 32, 33). Pass eventNum as a prop to both
components to determine when to hide the Name column. Fix event value
lookup in EventLeaderboard by changing modulo from 16 to 19.

These changes improve UI clarity by removing irrelevant Name data for
relay events and ensure correct event metadata is displayed.